### PR TITLE
Configuration object and partial validation

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ var ValidationEngine = require("./src/validation-engine");
 var rdflibgraph = require("./src/rdflib-graph");
 var RDFLibGraph = rdflibgraph.RDFLibGraph;
 var fs = require("fs");
+var ValidationEngineConfiguration = require("./src/validation-engine-configuration");
 
 /********************************/
 /* Vocabularies                 */
@@ -58,6 +59,7 @@ var SHACLValidator = function() {
     this.validationError = null;
     this.sequence = null;
     this.shapesGraph = new ShapesGraph(this);
+    this.configuration = new ValidationEngineConfiguration();
     this.functionsRegistry = require("./src/libraries");
 };
 
@@ -71,6 +73,10 @@ SHACLValidator.prototype.compareNodes = function(node1, node2) {
         }
     }
     return RDFQuery.compareTerms(node1, node2);
+};
+
+SHACLValidator.prototype.getConfiguration = function () {
+    return this.configuration;
 };
 
 SHACLValidator.prototype.nodeConformsToShape = function(focusNode, shapeNode) {
@@ -117,6 +123,7 @@ SHACLValidator.prototype.loadDataGraph = function(rdfGraph, andThen) {
 SHACLValidator.prototype.updateValidationEngine = function() {
     results = [];
     this.validationEngine = new ValidationEngine(this);
+    this.validationEngine.setConfiguration(this.configuration);
     try {
         this.validationError = null;
         if (this.sequence) {

--- a/src/validation-engine-configuration.js
+++ b/src/validation-engine-configuration.js
@@ -1,0 +1,17 @@
+
+var ValidationEngineConfiguration = function() {
+    // By default validate all errors
+    this.validationErrorBatch = -1;
+};
+
+
+ValidationEngineConfiguration.prototype.setValidationErrorBatch = function(validationErrorBatch) {
+    this.validationErrorBatch = validationErrorBatch;
+    return this;
+};
+
+ValidationEngineConfiguration.prototype.getValidationErrorBatch = function() {
+    return this.validationErrorBatch;
+};
+
+module.exports = ValidationEngineConfiguration;

--- a/test/configuration_tests.js
+++ b/test/configuration_tests.js
@@ -1,0 +1,20 @@
+var SHACLValidator = require("../index");
+
+var fs = require("fs");
+
+exports.maxErrorsTest = function(test) {
+    var validator = new SHACLValidator();
+
+    var data = fs.readFileSync(__dirname + "/data/core/property/class-001.test.ttl").toString();
+
+    validator.validate(data, "text/turtle", data, "text/turtle", function(e, report) {
+        test.ok(report.conforms() === false);
+        test.ok(report.results().length === 2);
+        validator.getConfiguration().setValidationErrorBatch(1);
+        validator.validate(data, "text/turtle", data, "text/turtle", function(e, report) {
+            test.ok(report.conforms() === false);
+            test.ok(report.results().length === 1);
+            test.done();
+        });
+    });
+};


### PR DESCRIPTION
This PR introduces a configuration option for the validation engine making it possible to stop the evaluation of the constraints, once a maximum number of errors have been reached.

The use case for this behaviour is situations where  we just need to know if the data graph is valid or not, regardless of the total number of errors. For example, where providing a validity service where we want to maximise the performance of the service and where failing fast is preferred to getting the complete set of validation errors.

To make it possible to configure this behaviour, a configuration object has been introduced where this option (and other future options) can be set-up.

Matching Java change: https://github.com/TopQuadrant/shacl/pull/36