### PR TITLE
Upgrade rdflib, properly ensure BlankNode ID

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "author": "Holger Knublauch <holger@topquadrant.com>",
   "license": "Apache-2.0",
   "dependencies": {
-    "rdflib": "^0.15.0"
+    "rdflib": "^1.0.6"
   },
   "devDependencies": {
     "gulp": "^3.9.1",

--- a/src/rdflib-graph.js
+++ b/src/rdflib-graph.js
@@ -107,9 +107,7 @@ RDFLibGraphIterator.prototype.next = function () {
 
 function ensureBlankId(component) {
     if (component.termType === "BlankNode") {
-        if (typeof(component.value) !== "string") {
-            component.value = "_:" + component.id;
-        }
+        component.value = "_:" + component.id;
         return component;
     }
 


### PR DESCRIPTION
Note: Tests are passing, but the browserify build fails because an npm dependency uses async/await.

Until everything is working, this PR is for informational purposes only.

---

This updates rdflib to the latest version, which might have support for JSON-LD 1.1.

Potential fix for #23